### PR TITLE
Added build path for thehyve images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   glowing-bear:
     container_name: glowing-bear
     image: thehyve/glowing-bear:2.0.0
+    build: https://github.com/thehyve/glowing-bear.git#2.0.0:docker
     ports:
       - 9080:80
       - 443:443
@@ -43,6 +44,7 @@ services:
   gb-backend:
     container_name: gb-backend
     image: thehyve/glowing-bear-backend:1.0.0
+    build: https://github.com/thehyve/gb-backend.git#1.0.0:docker
     environment:
       TRANSMART_API_SERVER_URL: ${TRANSMART_API_SERVER_URL}
       KEYCLOAK_SERVER_URL: ${KEYCLOAK_SERVER_URL}
@@ -77,6 +79,7 @@ services:
   transmart-api-server:
     container_name: transmart-api-server
     image: thehyve/transmart-api-server:17.1-HYVE-5.9
+    build: https://github.com/thehyve/transmart-core.git#v17.1-hyve-5.9-rc.4:docker/transmart-api-server
     environment:
       KEYCLOAK_SERVER_URL: ${KEYCLOAK_SERVER_URL}
       KEYCLOAK_REALM: ${KEYCLOAK_REALM}
@@ -103,6 +106,7 @@ services:
   transmart-packer:
     container_name: transmart-packer
     image: thehyve/transmart-packer:0.1.3
+    build: https://github.com/thehyve/transmart-packer.git#0.1.3:docker
     command: ['python', '-m', 'packer']
     depends_on:
       - redis
@@ -120,6 +124,7 @@ services:
   transmart-packer-worker:
     container_name: transmart-packer-worker
     image: thehyve/transmart-packer:0.1.3
+    build: https://github.com/thehyve/transmart-packer.git#0.1.3:docker
     command:  ['celery', '-A', 'packer.tasks', 'worker', '-c', '4', '--loglevel', 'info']
     depends_on:
       - redis


### PR DESCRIPTION
I added the build path for all thehyve images. This makes it easier to swap out an image for development or to test images that are not yet uploaded to docker hub.

Use:
`docker-compose pull` to use images from docker hub
`docker-compose build` to build the images yourself

fyi: thehyve/glowing-bear:2.0.0 is not yet pushed to docker hub