### PR TITLE
 Fix REST APIs connection issues 

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,3 @@
-TRANSMART_API_SERVER_URL=/api/transmart-api-server
-TRANSMART_PACKER_URL=/api/transmart-packer
-GB_BACKEND_URL=/api/gb-backend
 KEYCLOAK_SERVER_URL=https://keycloak-dwh-test.thehyve.net
 KEYCLOAK_REALM=transmart-dev
 KEYCLOAK_CLIENT_ID=transmart-client

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       POSTGRES_PASSWORD: gb
       POSTGRES_DB: gb_backend
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - gb-backend-db-data:/var/lib/postgresql/data
     networks:
       - gb-backend-db-network
     restart: unless-stopped
@@ -109,7 +109,7 @@ services:
   transmart-packer:
     container_name: transmart-packer
     image: thehyve/transmart-packer:0.1.3
-    command: ['python', '-m', 'packer']
+    command: ['transmart-packer']
     depends_on:
       - redis
       - transmart-api-server
@@ -124,6 +124,8 @@ services:
     networks:
       - nginx-proxy-network
       - packer-redis-network
+    volumes:
+      - export-data:/app/tmp_data_dir
     restart: unless-stopped
   transmart-packer-worker:
     container_name: transmart-packer-worker
@@ -139,12 +141,15 @@ services:
     networks:
       - nginx-proxy-network
       - packer-redis-network
+    volumes:
+      - export-data:/app/tmp_data_dir
     restart: unless-stopped
 
 volumes:
-  db-data:
+  gb-backend-db-data:
   transmart-db-data:
   redis-data:
+  export-data:
 networks:
   gb-backend-db-network:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,9 @@ services:
       - 9080:80
       - 443:443
     environment:
-      TRANSMART_API_SERVER_URL: ${TRANSMART_API_SERVER_URL}
-      TRANSMART_PACKER_URL: ${TRANSMART_PACKER_URL}
-      GB_BACKEND_URL: ${GB_BACKEND_URL}
+      TRANSMART_API_SERVER_URL: /api/transmart-api-server
+      TRANSMART_PACKER_URL: /api/transmart-packer
+      GB_BACKEND_URL: /api/gb-backend
       KEYCLOAK_SERVER_URL: ${KEYCLOAK_SERVER_URL}
       KEYCLOAK_REALM: ${KEYCLOAK_REALM}
       KEYCLOAK_CLIENT_ID: ${KEYCLOAK_CLIENT_ID}
@@ -46,7 +46,7 @@ services:
     container_name: gb-backend
     image: thehyve/glowing-bear-backend:1.0.0
     environment:
-      TRANSMART_API_SERVER_URL: ${TRANSMART_API_SERVER_URL}
+      TRANSMART_API_SERVER_URL: http://transmart-api-server:8081
       KEYCLOAK_SERVER_URL: ${KEYCLOAK_SERVER_URL}
       KEYCLOAK_REALM: ${KEYCLOAK_REALM}
       KEYCLOAK_CLIENT_ID: ${KEYCLOAK_CLIENT_ID}
@@ -112,10 +112,11 @@ services:
     command: ['python', '-m', 'packer']
     depends_on:
       - redis
+      - transmart-api-server
     links:
       - redis
     environment:
-      TRANSMART_URL: ${TRANSMART_API_SERVER_URL}
+      TRANSMART_URL: http://transmart-api-server:8081
       KEYCLOAK_SERVER_URL: ${KEYCLOAK_SERVER_URL}
       KEYCLOAK_REALM: ${KEYCLOAK_REALM}
       KEYCLOAK_CLIENT_ID: ${KEYCLOAK_CLIENT_ID}
@@ -130,11 +131,13 @@ services:
     command:  ['celery', '-A', 'packer.tasks', 'worker', '-c', '4', '--loglevel', 'info']
     depends_on:
       - redis
+      - transmart-api-server
     links:
       - redis
     environment:
-      TRANSMART_URL: ${TRANSMART_API_SERVER_URL}
+      TRANSMART_URL: http://transmart-api-server:8081
     networks:
+      - nginx-proxy-network
       - packer-redis-network
     restart: unless-stopped
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   # ----- glowing-bear -----
   glowing-bear:
     container_name: glowing-bear
-    image: thehyve/glowing-bear:2.0.1
+    image: thehyve/glowing-bear:2.0.2
     ports:
       - 9080:80
       - 443:443


### PR DESCRIPTION
Included fixes:
- connection between gb-backend and transmart-api-server
- connection between tm-packer and transmart-api-server
- transmart-packer volumes - downloading of the export jobs

Related issue: [TMT-924](https://jira.thehyve.nl/browse/TMT-924)