### PR TITLE
Configure journald as logging driver.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,35 +4,34 @@ Docker compose script for Glowing Bear and its dependencies.
 
 ## Configuration
 
-The default environmental variables are defined in [`.env`](../.env) file.
+The default environment variables are defined in the [`.env`](.env) file.
 
-#### Authentication
+### Authentication
 
 Applications use Keycloak for authentication, however it is not a part of this script. 
-The assumption is that there is already a Keycloak server running, connection to which can be configured
- by setting the variables below:
-
+The assumption is that there is already a Keycloak server running, connection to which is configured
+by setting the variables below:
 
 Variable              | Description
-----------------------|---------------
-`KEYCLOAK_SERVER_URL` | url of the Keycloak server e.g. `https://keycloak-dwh-test.thehyve.net`
+:-------------------- |:---------------
+`KEYCLOAK_SERVER_URL` | URL of the Keycloak server e.g. `https://keycloak-dwh-test.thehyve.net`
 `KEYCLOAK_REALM`      | Keycloak realm, e.g. `transmart-dev`
 `KEYCLOAK_CLIENT_ID`  | Keycloak client id, e.g. `transmart-client`
 
-
 Current configuration supports Keycloak version <= `4.5`.
 
-#### Connection
+### Connection
 
-Configuring a connection over either HTTP, or HTTPS is supported. In a current setup [Nginx](https://www.nginx.com/) is used as a reverse proxy.
-There are two main variables required to be specified:
+Configuring a connection over either HTTP, or HTTPS is supported.
+[Nginx](https://www.nginx.com/) is used as a reverse proxy.
+The following variables are required to be specified:
 
 Variable                | Description
-------------------------|---------------------------
+:---------------------- |:--------------------------
 `NGINX_HOST`            | Name of the server (default: `localhost`)
 `NGINX_PORT`            | `80` if applications should be available via HTTP or <br/>`443 ssl` if applications should be available via HTTPS
 
-###### SSL
+#### SSL
 
 To configure SSL, follow the steps below:
 1. Set the `NGINX_PORT` to `443 ssl`.
@@ -49,11 +48,11 @@ ssl_certificate /etc/nginx/server.crt;
 ssl_certificate_key /etc/nginx/server.key;
 ```
 
-
 To generate a self-signed certificate run, e.g.:
 ```bash
 openssl req -new -newkey rsa:4096 -x509 -sha256 -days 365 -nodes -out nginx/server.crt -keyout nginx/server.key -subj "/C=NL/ST=Utrecht/L=Utrecht/O=The Hyve/CN=localhost"
 ```
+
 
 ## Run
 
@@ -72,7 +71,7 @@ This starts:
 Glowing Bear and the the APIs of other services can be reached using the following urls:
 
 Application                | URL
----------------------------|---------------------------
+:------------------------- |:--------------------------
 Glowing Bear               | `$HOSTNAME`
 TranSMART Api Server       | `$HOSTNAME`/api/transmart-api-server
 TranSMART Packer           | `$HOSTNAME`/api/transmart-packer
@@ -80,7 +79,19 @@ Gb Backend                 | `$HOSTNAME`/api/gb-backend
 
 Where the `$HOSTNAME` is defined based on `$NGINX_HOST` and `$NGINX_PORT` variables: (e.g.: `https://localhost`).
 
-Additionally TranSMART database will be exposed at port `9432`.
+Additionally, the TranSMART database server will be exposed at port `9432`.
+
+### Logs
+
+Logs are written to `journald`. The logs can be inspected with
+```bash
+journalctl -f -u docker.service
+```
+and for individual services with `docker logs <service-name> -f`, e.g.,
+```bash
+docker logs transmart-api-server -f
+```
+
 
 ## Development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,7 @@
 version: '3'
+
 services:
+
   # ----- glowing-bear -----
   glowing-bear:
     container_name: glowing-bear
@@ -20,7 +22,7 @@ services:
       - gb-backend
       - transmart-api-server
       - transmart-packer
-    #optional volumes for ssl certificates, required if `NGINX_PORT=443 ssl`
+    # optional volumes for ssl certificates, required if `NGINX_PORT=443 ssl`
     volumes:
       - ./nginx/server.crt:/etc/nginx/server.crt
       - ./nginx/server.key:/etc/nginx/server.key
@@ -28,6 +30,11 @@ services:
     networks:
       - nginx-proxy-network
     restart: unless-stopped
+    logging:
+      driver: journald
+      options:
+        labels: application
+        tag: glowing-bear
 
   # ----- gb-backend + db -----
   gb-backend-database:
@@ -42,6 +49,12 @@ services:
     networks:
       - gb-backend-db-network
     restart: unless-stopped
+    logging:
+      driver: journald
+      options:
+        labels: application
+        tag: gb-backend-database
+
   gb-backend:
     container_name: gb-backend
     image: thehyve/glowing-bear-backend:1.0.0
@@ -62,6 +75,11 @@ services:
       - gb-backend-db-network
       - nginx-proxy-network
     restart: unless-stopped
+    logging:
+      driver: journald
+      options:
+        labels: application
+        tag: gb-backend
 
   # ----- transmart-api-server + db -----
   transmart-database:
@@ -78,6 +96,12 @@ services:
     networks:
       - transmart-db-network
     restart: unless-stopped
+    logging:
+      driver: journald
+      options:
+        labels: application
+        tag: transmart-database
+
   transmart-api-server:
     container_name: transmart-api-server
     image: thehyve/transmart-api-server:17.1-HYVE-5.9
@@ -94,6 +118,11 @@ services:
       - transmart-db-network
       - nginx-proxy-network
     restart: unless-stopped
+    logging:
+      driver: journald
+      options:
+        labels: application
+        tag: transmart-api-server
 
   # ----- transmart-packer -----
   redis:
@@ -106,6 +135,12 @@ services:
     networks:
       - packer-redis-network
     restart: unless-stopped
+    logging:
+      driver: journald
+      options:
+        labels: application
+        tag: redis
+
   transmart-packer:
     container_name: transmart-packer
     image: thehyve/transmart-packer:0.1.3
@@ -127,6 +162,12 @@ services:
     volumes:
       - export-data:/app/tmp_data_dir
     restart: unless-stopped
+    logging:
+      driver: journald
+      options:
+        labels: application
+        tag: transmart-packer
+
   transmart-packer-worker:
     container_name: transmart-packer-worker
     image: thehyve/transmart-packer:0.1.3
@@ -144,12 +185,18 @@ services:
     volumes:
       - export-data:/app/tmp_data_dir
     restart: unless-stopped
+    logging:
+      driver: journald
+      options:
+        labels: application
+        tag: transmart-packer-worker
 
 volumes:
   gb-backend-db-data:
   transmart-db-data:
   redis-data:
   export-data:
+
 networks:
   gb-backend-db-network:
     driver: bridge


### PR DESCRIPTION
Write logs to `journald` instead of to json files in `/var/lib/docker/containers`.
Journald can then be configured for further processing, log rotation, etc.
The journal can be inspected with `journalctl -f -u docker.service`, and for individual containers
with, e.g., `docker logs transmart-api-server -f`.