### PR TITLE
Automatically Setup Keycloak Realm

### DIFF
--- a/keycloak.yml
+++ b/keycloak.yml
@@ -20,7 +20,7 @@ services:
         tag: keycloak-postgres
 
   keycloak:
-    image: jboss/keycloak:4.5.0.Final
+    image: jboss/keycloak:6.0.1
     container_name: keycloak
     environment:
       DB_VENDOR: POSTGRES
@@ -33,13 +33,20 @@ services:
       KEYCLOAK_HOSTNAME: ${KEYCLOAK_HOSTNAME:?Please configure KEYCLOAK_HOSTNAME.}
       KEYCLOAK_HTTP_PORT: 80
       KEYCLOAK_HTTPS_PORT: 443
+      KEYCLOAK_IMPORT: /tmp/realm-export.json
+      KEYCLOAK_REALM: ${KEYCLOAK_REALM:?Please configure KEYCLOAK_REALM}
+      KEYCLOAK_CLIENT_ID: ${KEYCLOAK_CLIENT_ID:?Please configure KEYCLOAK_CLIENT_ID}
       PROXY_ADDRESS_FORWARDING: 'true'
+      GLOWINGBEAR_HOSTNAME: ${GLOWINGBEAR_HOSTNAME:?Please configure GLOWINGBEAR_HOSTNAME.}
     ports:
       - 8080:8080
     depends_on:
       - keycloak-postgres
     networks:
       - keycloak-db-network
+    volumes:
+      - ./keycloak/setup-realm.sh:/opt/jboss/startup-scripts/setup-realm.sh
+      - ./keycloak/realm-template.json:/tmp/realm-template.json
     restart: unless-stopped
     logging:
       driver: ${DOCKER_LOGGING_DRIVER:-journald}

--- a/keycloak/realm-template.json
+++ b/keycloak/realm-template.json
@@ -1,6 +1,6 @@
 {
-  "id": "transmart",
-  "realm": "transmart",
+  "id": "${KEYCLOAK_REALM}",
+  "realm": "${KEYCLOAK_REALM}",
   "displayName": "Glowing Bear login",
   "displayNameHtml": "",
   "notBefore": 0,
@@ -66,7 +66,7 @@
       "id": "7956f8a1-3377-4027-897a-fd2fd991beee",
       "clientId": "account",
       "name": "${client_account}",
-      "baseUrl": "/auth/realms/transmart/account",
+      "baseUrl": "/auth/realms/${KEYCLOAK_REALM}/account",
       "surrogateAuthRequired": false,
       "enabled": true,
       "clientAuthenticatorType": "client-secret",
@@ -76,7 +76,7 @@
         "manage-account"
       ],
       "redirectUris": [
-        "/auth/realms/transmart/account/*"
+        "/auth/realms/${KEYCLOAK_REALM}/account/*"
       ],
       "webOrigins": [],
       "notBefore": 0,
@@ -213,13 +213,13 @@
       "id": "b7a96857-6070-4737-a543-87a55f00bdf9",
       "clientId": "security-admin-console",
       "name": "${client_security-admin-console}",
-      "baseUrl": "/auth/admin/transmart/console/index.html",
+      "baseUrl": "/auth/admin/${KEYCLOAK_REALM}/console/index.html",
       "surrogateAuthRequired": false,
       "enabled": true,
       "clientAuthenticatorType": "client-secret",
       "secret": "**********",
       "redirectUris": [
-        "/auth/admin/transmart/console/*"
+        "/auth/admin/${KEYCLOAK_REALM}/console/*"
       ],
       "webOrigins": [],
       "notBefore": 0,
@@ -266,14 +266,14 @@
     },
     {
       "id": "8a168049-f7e7-4c32-bfd6-0b5f4c75c1fa",
-      "clientId": "transmart-client",
-      "baseUrl": "https://glowingbear",
+      "clientId": "${KEYCLOAK_CLIENT_ID}",
+      "baseUrl": "https://${GLOWINGBEAR_HOSTNAME}",
       "surrogateAuthRequired": false,
       "enabled": true,
       "clientAuthenticatorType": "client-secret",
       "secret": "**********",
       "redirectUris": [
-        "https://glowingbear/*"
+        "https://${GLOWINGBEAR_HOSTNAME}"
       ],
       "webOrigins": [
         "*"

--- a/keycloak/setup-realm.sh
+++ b/keycloak/setup-realm.sh
@@ -1,0 +1,1 @@
+perl -pe 's/\$\{([^}]+)\}/defined $ENV{$1} ? $ENV{$1} : $&/eg; s/\$\{([^}]+)\}//eg' < /tmp/realm-template.json > /tmp/realm-export.json


### PR DESCRIPTION
Added a script (like envsubst) to automatically populate the Keycloak template realm with `KEYCLOAK_REALM`,  `KEYCLOAK_CLIENT_ID` and `GLOWINGBEAR_HOSTNAME`