### PR TITLE
[glowing-bear-ssl-proxy] replaced internal docker ip addresses with dns names

### DIFF
--- a/docker/glowingbear-ssl-proxy/docker-entrypoint.sh
+++ b/docker/glowingbear-ssl-proxy/docker-entrypoint.sh
@@ -16,7 +16,7 @@ cat > /etc/nginx/sites-enabled/glowingbear.conf <<EndOfMessage
      index                 index.html;
 
      location / {
-       proxy_pass            http://172.17.0.1:9080/;
+       proxy_pass            http://glowing-bear:9080/;
        proxy_read_timeout    90s;
        proxy_connect_timeout 90s;
        proxy_send_timeout    90s;
@@ -48,7 +48,7 @@ cat > /etc/nginx/sites-enabled/keycloak.conf <<EndOfMessage
      index                 index.html;
 
      location / {
-       proxy_pass            http://172.17.0.1:8080/;
+       proxy_pass            http://keycloak:8080/;
        proxy_read_timeout    90s;
        proxy_connect_timeout 90s;
        proxy_send_timeout    90s;

--- a/glowingbear-ssl-proxy.yml
+++ b/glowingbear-ssl-proxy.yml
@@ -10,6 +10,9 @@ services:
     volumes:
       - ./ssl/server.pem:/etc/nginx/server.pem
       - ./ssl/server.key:/etc/nginx/server.key
+    networks:
+      - keycloak-network
+      - nginx-proxy-network
     ports:
       - 80:80
       - 443:443

--- a/keycloak.yml
+++ b/keycloak.yml
@@ -44,6 +44,7 @@ services:
       - keycloak-postgres
     networks:
       - keycloak-db-network
+      - keycloak-network
     volumes:
       - ./keycloak/setup-realm.sh:/opt/jboss/startup-scripts/setup-realm.sh
       - ./keycloak/realm-template.json:/tmp/realm-template.json
@@ -59,4 +60,6 @@ volumes:
 
 networks:
   keycloak-db-network:
+    driver: bridge
+  keycloak-network:
     driver: bridge


### PR DESCRIPTION
Fixes #44 